### PR TITLE
[WAI-16] Blocked randomization for case/model pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository implements a reproducible harness for auditing fairness in inter
 
 ## Features
 - Multi‑agent trial simulation with roles: judge, prosecution, defense
-- Paired cue toggling (control/treatment) with blocked randomization
+- Paired cue toggling (control/treatment) with case×model blocked randomization plus placebo tagging in logs
 - Budgets/guards: per‑role byte caps, per‑phase message caps, judge blinding
 - Structured logs with event tags (objections, interruptions, safety)
 - Metrics: paired McNemar log‑odds, flip rate, byte share, measurement‑error correction, basic tone utilities
@@ -19,6 +19,7 @@ This repository implements a reproducible harness for auditing fairness in inter
    - Echo: `python scripts/run_pilot_trial.py --config configs/pilot.yaml --backend echo --out trial_logs.jsonl`
    - Groq: `python scripts/run_pilot_trial.py --config configs/pilot.yaml --backend groq --model llama3-8b-8192 --out trial_logs.jsonl`
    - Gemini: `python scripts/run_pilot_trial.py --config configs/pilot.yaml --backend gemini --model gemini-1.5-flash --out trial_logs.jsonl`
+   - Add `--placebo <key>` (e.g., `name_placebo`) to schedule additional negative-control pairs if you are not using the sample YAML.
 
 ## Repository Layout
 - `bailiff/core`: State machine, config, logging, session engine, JSONL I/O
@@ -39,4 +40,3 @@ This repository implements a reproducible harness for auditing fairness in inter
 - How do I add a new case? Create a YAML under `bailiff/datasets/cases/` with `summary`, `facts`, `witnesses`, and `cue_slots`. See the user guide.
 - How do I add a cue? Extend `cue_catalog()` in `bailiff/datasets/templates.py`.
 - How do I analyze results? Export JSONL from the runner and follow the analysis examples in `docs/USER_GUIDE.md`.
-

--- a/bailiff/core/config.py
+++ b/bailiff/core/config.py
@@ -84,6 +84,8 @@ class TrialConfig:
     # Active cue assignment details (set by orchestration when pairing)
     cue_condition: Optional[str] = None  # "control" | "treatment"
     cue_value: Optional[str] = None
+    block_key: Optional[str] = None
+    is_placebo: bool = False
     # Policy toggles
     judge_blinding: bool = False
     # NEW: Enhanced blinding mode that redacts BOTH control and treatment cue values

--- a/bailiff/core/events.py
+++ b/bailiff/core/events.py
@@ -50,6 +50,8 @@ class TrialLog:
     cue_name: str
     cue_condition: Optional[str]
     cue_value: Optional[str]
+    block_key: Optional[str] = None
+    is_placebo: bool = False
     seed: int
     started_at: datetime
     completed_at: Optional[datetime]

--- a/bailiff/core/logging.py
+++ b/bailiff/core/logging.py
@@ -19,6 +19,8 @@ def default_log_factory(config: TrialConfig) -> TrialLog:
         cue_name=config.cue.name,
         cue_condition=config.cue_condition,
         cue_value=config.cue_value,
+        block_key=config.block_key,
+        is_placebo=config.is_placebo,
         seed=config.seed,
         started_at=started,
         completed_at=None,

--- a/bailiff/orchestration/__init__.py
+++ b/bailiff/orchestration/__init__.py
@@ -1,10 +1,19 @@
 ﻿from .pipeline import PairPlan, TrialPipeline, TrialPlan
-from .randomization import PairAssignment, blocked_permutations
+from .randomization import (
+    PairAssignment,
+    RandomizationBlock,
+    block_identifier,
+    blocked_permutations,
+    blockwise_permutations,
+)
 
 __all__ = [
+    "RandomizationBlock",
     "PairAssignment",
     "PairPlan",
     "TrialPipeline",
     "TrialPlan",
+    "block_identifier",
     "blocked_permutations",
+    "blockwise_permutations",
 ]

--- a/bailiff/orchestration/randomization.py
+++ b/bailiff/orchestration/randomization.py
@@ -13,9 +13,45 @@ class PairAssignment:
     seed: int
     control_value: str
     treatment_value: str
+    cue_name: str | None = None
+    block_key: str | None = None
+    case_identifier: str | None = None
+    model_identifier: str | None = None
+    is_placebo: bool = False
 
 
-def blocked_permutations(values: Sequence[str], seeds: Iterable[int]) -> Iterator[PairAssignment]:
+@dataclass(slots=True)
+class RandomizationBlock:
+    """Definition of a block (case × model × cue) to randomize within."""
+
+    case_identifier: str
+    model_identifier: str
+    cue_name: str
+    values: Sequence[str]
+    seeds: Sequence[int]
+    is_placebo: bool = False
+
+    @property
+    def block_key(self) -> str:
+        return block_identifier(self.case_identifier, self.model_identifier)
+
+
+def block_identifier(case_identifier: str, model_identifier: str) -> str:
+    """Return a canonical identifier for a case × model block."""
+
+    return f"{case_identifier}:{model_identifier}"
+
+
+def blocked_permutations(
+    values: Sequence[str],
+    seeds: Iterable[int],
+    *,
+    cue_name: str | None = None,
+    block_key: str | None = None,
+    case_identifier: str | None = None,
+    model_identifier: str | None = None,
+    is_placebo: bool = False,
+) -> Iterator[PairAssignment]:
     """Yield pair assignments by shuffling within seeds."""
 
     for seed in seeds:
@@ -24,4 +60,28 @@ def blocked_permutations(values: Sequence[str], seeds: Iterable[int]) -> Iterato
         rng.shuffle(shuffled)
         if len(shuffled) < 2:
             raise ValueError("At least two values required for blocked permutations.")
-        yield PairAssignment(seed=seed, control_value=shuffled[0], treatment_value=shuffled[1])
+        yield PairAssignment(
+            seed=seed,
+            control_value=shuffled[0],
+            treatment_value=shuffled[1],
+            cue_name=cue_name,
+            block_key=block_key,
+            case_identifier=case_identifier,
+            model_identifier=model_identifier,
+            is_placebo=is_placebo,
+        )
+
+
+def blockwise_permutations(blocks: Iterable[RandomizationBlock]) -> Iterator[PairAssignment]:
+    """Yield assignments for each block definition."""
+
+    for block in blocks:
+        yield from blocked_permutations(
+            block.values,
+            block.seeds,
+            cue_name=block.cue_name,
+            block_key=block.block_key,
+            case_identifier=block.case_identifier,
+            model_identifier=block.model_identifier,
+            is_placebo=block.is_placebo,
+        )

--- a/configs/pilot.yaml
+++ b/configs/pilot.yaml
@@ -25,3 +25,5 @@ phase_budgets:
     max_messages: 1
   - phase: audit
     max_messages: 1
+placebos:
+  - name_placebo

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,13 +8,13 @@ This is a concise reference of the primary classes and functions. Import paths a
   - `AgentBudget(max_bytes, max_tokens=None, max_turns=None)`
   - `PhaseBudget(phase, max_messages=2, allow_interruptions=False)`
   - `CueToggle(name, control_value, treatment_value, metadata={})`
-  - `TrialConfig(case_template, cue, model_identifier, seed, agent_budgets, phase_budgets, ..., cue_condition=None, cue_value=None, judge_blinding=False)`
+  - `TrialConfig(case_template, cue, model_identifier, seed, agent_budgets, phase_budgets, ..., cue_condition=None, cue_value=None, block_key=None, is_placebo=False, judge_blinding=False)`
   - `DEFAULT_PHASE_ORDER: list[Phase]`
 - `bailiff.core.events`
   - `ObjectionRuling` — Enum
   - `EventTag(name, value=None)`
   - `UtteranceLog(role, phase, content, byte_count, token_count, addressed_to, timestamp, interruption=False, objection_raised=False, objection_ruling=None, safety_triggered=False, tags=[])`
-  - `TrialLog(trial_id, case_identifier, model_identifier, cue_name, cue_condition, cue_value, seed, started_at, completed_at, utterances=[], verdict=None, sentence=None, schema_version='0.1')`
+  - `TrialLog(trial_id, case_identifier, model_identifier, cue_name, cue_condition, cue_value, block_key, is_placebo, seed, started_at, completed_at, utterances=[], verdict=None, sentence=None, schema_version='0.1')`
 - `bailiff.core.logging`
   - `default_log_factory(config) -> TrialLog`
   - `mark_completed(log) -> None`
@@ -27,8 +27,11 @@ This is a concise reference of the primary classes and functions. Import paths a
 
 ## Orchestration
 - `bailiff.orchestration.randomization`
-  - `PairAssignment(seed, control_value, treatment_value)`
-  - `blocked_permutations(values, seeds) -> Iterator[PairAssignment]`
+  - `PairAssignment(seed, control_value, treatment_value, cue_name=None, block_key=None, ...)`
+  - `RandomizationBlock(case_identifier, model_identifier, cue_name, values, seeds, is_placebo=False)`
+  - `block_identifier(case_identifier, model_identifier) -> str`
+  - `blocked_permutations(values, seeds, *, cue_name=None, block_key=None, ...) -> Iterator[PairAssignment]`
+  - `blockwise_permutations(blocks) -> Iterator[PairAssignment]`
 - `bailiff.orchestration.pipeline`
   - `TrialPlan(config, cue_value)`
   - `PairPlan(control: TrialPlan, treatment: TrialPlan)`
@@ -36,6 +39,7 @@ This is a concise reference of the primary classes and functions. Import paths a
     - `.build_session(config) -> TrialSession`
     - `.run_pair(plan) -> list[TrialLog]`
     - `.assign_pairs(base_config, assignments) -> Iterator[PairPlan]`
+    - `.assign_blocked_pairs(block_configs, assignments) -> Iterator[PairPlan]`
 
 ## Agents
 - `bailiff.agents.base`
@@ -83,4 +87,3 @@ This is a concise reference of the primary classes and functions. Import paths a
   - `tost_log_odds(est, se, delta=0.1) -> (equivalent, p_lower, p_upper)`
   - `randomization_inference(stat_fn, y_control, y_treat, reps=1000, seed=123) -> float`
   - `wild_cluster_bootstrap(stat_fn, y_control, y_treat, reps=1000, seed=123) -> (p5, p95)`
-


### PR DESCRIPTION
## Summary
- add RandomizationBlock metadata plus helpers so each case×model pair stays in the same cue assignment with optional placebos and judge blinding
- thread blocked assignments through the TrialPipeline, pilot config, and logging so manifests capture block keys, cue names, and placebo flags
- document how to configure the new knobs in README/API/USER_GUIDE and refresh the pilot script defaults

## Testing
- Not run (not requested)

## Linear
- WAI-16