### PR TITLE
[WAI-6] Enforce token budgets and counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository implements a reproducible harness for auditing fairness in inter
 ## Features
 - Multi‑agent trial simulation with roles: judge, prosecution, defense
 - Paired cue toggling (control/treatment) with case×model blocked randomization plus placebo tagging in logs
-- Budgets/guards: per‑role byte caps, per‑phase message caps, judge blinding
+- Budgets/guards: per-role byte & token caps, per-phase message caps, judge blinding
 - Structured logs with event tags (objections, interruptions, safety)
 - Metrics: paired McNemar log‑odds, flip rate, byte share, measurement‑error correction, basic tone utilities
 - Extensible backends: Echo (offline), Groq, Gemini; open‑source adapters are easy to add

--- a/bailiff/core/tokenizer.py
+++ b/bailiff/core/tokenizer.py
@@ -1,0 +1,73 @@
+"""Lightweight tokenization helpers used for budget enforcement."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+try:  # pragma: no cover - optional dependency
+    import tiktoken  # type: ignore
+except Exception:  # pragma: no cover - gracefully degrade when unavailable
+    tiktoken = None
+
+_WORD_RE = re.compile(r"\S+")
+
+
+@dataclass(slots=True)
+class Tokenizer:
+    """Wrapper around tiktoken with a safe fallback."""
+
+    model: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self._encoder = None
+        if tiktoken is None:
+            return
+        if self.model:
+            try:
+                self._encoder = tiktoken.encoding_for_model(self.model)
+                return
+            except Exception:
+                pass
+        # Fall back to a generic encoding when model lookup fails.
+        try:
+            self._encoder = tiktoken.get_encoding("cl100k_base")
+        except Exception:
+            self._encoder = None
+
+    def count(self, text: str) -> int:
+        """Return the number of tokens contained in ``text``."""
+
+        if self._encoder is not None:
+            return len(self._encoder.encode(text))
+        return sum(1 for _ in _WORD_RE.finditer(text))
+
+    def clip(self, text: str, max_tokens: int) -> tuple[str, int]:
+        """Clip ``text`` to ``max_tokens`` and return (clipped_text, tokens_used)."""
+
+        if max_tokens <= 0:
+            return "", 0
+        if self._encoder is not None:
+            tokens = self._encoder.encode(text)
+            if len(tokens) <= max_tokens:
+                return text, len(tokens)
+            clipped = tokens[:max_tokens]
+            return self._encoder.decode(clipped), len(clipped)
+        return _fallback_clip(text, max_tokens)
+
+
+def _fallback_clip(text: str, max_tokens: int) -> tuple[str, int]:
+    """Whitespace-aware tokenizer for environments without tiktoken."""
+
+    if max_tokens <= 0:
+        return "", 0
+    count = 0
+    end_index = len(text)
+    for match in _WORD_RE.finditer(text):
+        count += 1
+        if count == max_tokens:
+            end_index = match.end()
+            break
+    if count < max_tokens:
+        return text, count
+    return text[:end_index], max_tokens

--- a/configs/pilot.yaml
+++ b/configs/pilot.yaml
@@ -6,10 +6,13 @@ cue: name_ethnicity
 agent_budgets:
   judge:
     max_bytes: 1500
+    max_tokens: 600
   prosecution:
     max_bytes: 1800
+    max_tokens: 700
   defense:
     max_bytes: 1800
+    max_tokens: 700
 phase_budgets:
   - phase: opening
     max_messages: 2

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -28,6 +28,7 @@ Paired mini-trials with LLM agents (judge, prosecution, defense) test whether to
 - Every log row follows `bailiff/schemas/trial_log.schema.json` (schema version recorded in `schema_version`).
 - Validation runs automatically whenever `write_jsonl`/`append_jsonl` are called. Set `BAILIFF_VALIDATE_LOGS=0` to disable (e.g., for very large batches).
 - Validation failures raise a `jsonschema.ValidationError` highlighting the offending field.
+- Each `UtteranceLog` now records `token_count` alongside `byte_count`, and `max_tokens` in `AgentBudget` clips agent outputs before they are logged.
 
 ## Backend retry policy
 - `scripts/run_pilot_trial.py` exposes `--timeout-seconds`, `--max-retries`, `--backoff-seconds`, `--backoff-multiplier`, and `--rate-limit-seconds` plus YAML overrides under `backend_policy`.
@@ -50,9 +51,9 @@ cases = sorted(Path("bailiff/datasets/cases").glob("*.yaml"))
 cue = cue_catalog()["name_ethnicity"]
 placebo = list(placebo_catalog())[0]
 budgets = {
-    Role.JUDGE: AgentBudget(1500),
-    Role.PROSECUTION: AgentBudget(1800),
-    Role.DEFENSE: AgentBudget(1800),
+    Role.JUDGE: AgentBudget(max_bytes=1500, max_tokens=600),
+    Role.PROSECUTION: AgentBudget(max_bytes=1800, max_tokens=700),
+    Role.DEFENSE: AgentBudget(max_bytes=1800, max_tokens=700),
 }
 phase_budgets = [PhaseBudget(phase=p) for p in Phase]
 agents = {r: AgentSpec(role=r, system_prompt=prompt_for(r), backend=EchoBackend()) for r in Role}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
   "pydantic-settings>=2.1",
   "pyyaml>=6.0",
   "python-dotenv>=1.0",
-  "tqdm>=4.66"
+  "tqdm>=4.66",
+  "tiktoken>=0.7"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add a tokenizer helper (tiktoken when available, whitespace fallback) plus per-role token accounting in TrialSession
- enforce max_tokens alongside byte/message limits and log 	oken_count on every UtteranceLog
- document the new knobs in README/USER_GUIDE/configs and require 	iktoken>=0.7

## Testing
- Not run (not requested)

## Linear
- WAI-6