### PR TITLE
feat(WAI-31): Implement multi-key Groq runner

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+GROQ_API_KEYS=["your_key1","your_key2","your_key3"]
+GROQ_API_KEY_CONCURRENCY={"your_key1":2,"your_key2":3}
+DEFAULT_MAX_CONCURRENCY=3

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ bailiff.egg-info/
 trial_logs*.*
 outcomes.csv
 bootstrap.json
+
+# build directory
+build/

--- a/bailiff.egg-info/PKG-INFO
+++ b/bailiff.egg-info/PKG-INFO
@@ -10,11 +10,14 @@ Requires-Dist: numpy>=1.24
 Requires-Dist: pandas>=2.0
 Requires-Dist: scipy>=1.10
 Requires-Dist: statsmodels>=0.14
+Requires-Dist: jsonschema>=4.21
 Requires-Dist: pydantic>=2.5
 Requires-Dist: pydantic-settings>=2.1
 Requires-Dist: pyyaml>=6.0
 Requires-Dist: python-dotenv>=1.0
 Requires-Dist: tqdm>=4.66
+Requires-Dist: scikit-learn>=1.3
+Requires-Dist: tiktoken>=0.7
 Provides-Extra: agent
 Requires-Dist: openai>=1.40; extra == "agent"
 Requires-Dist: anthropic>=0.34; extra == "agent"
@@ -24,6 +27,9 @@ Provides-Extra: analysis
 Requires-Dist: matplotlib>=3.8; extra == "analysis"
 Requires-Dist: seaborn>=0.13; extra == "analysis"
 Requires-Dist: plotnine>=0.12; extra == "analysis"
+Provides-Extra: local
+Requires-Dist: transformers>=4.41; extra == "local"
+Requires-Dist: llama-cpp-python>=0.2; extra == "local"
 
 # B.A.I.L.I.F.F. — Bias Analysis in Interactive Legal Intelligence & Fairness Framework
 
@@ -31,39 +37,66 @@ This repository implements a reproducible harness for auditing fairness in inter
 
 ## Features
 - Multi‑agent trial simulation with roles: judge, prosecution, defense
-- Paired cue toggling (control/treatment) with blocked randomization
-- Budgets/guards: per‑role byte caps, per‑phase message caps, judge blinding
+- Paired cue toggling (control/treatment) with case×model blocked randomization plus placebo tagging in logs
+- Budgets/guards: per-role byte & token caps, per-phase message caps, judge blinding
 - Structured logs with event tags (objections, interruptions, safety)
-- Metrics: paired McNemar log‑odds, flip rate, byte share, measurement‑error correction, basic tone utilities
-- Extensible backends: Echo (offline), Groq, Gemini; open‑source adapters are easy to add
+- Metrics: paired McNemar log-odds, flip rate, byte share, measurement-error correction, frozen tone classifier with calibration (Platt, ECE, ?)
+- Extensible backends: Echo (offline), Local (transformers/llama.cpp), Groq, Gemini; open-source adapters are easy to add
+- Batch driver with resumable manifests for running K×L×N matrices
+- Versioned JSON Schema validation for TrialLog output (toggle via `BAILIFF_VALIDATE_LOGS=0`)
+- Configurable backend hardening (timeouts, retries, rate-limit sleeps) with metadata captured in logs
 
 ## Quickstart
 1. Create a virtual environment and install:
    - `python -m venv .venv && .venv\Scripts\activate` (Windows) or `source .venv/bin/activate`
    - `pip install -e .[analysis,agent]`
-2. (Optional) Set API keys: `GROQ_API_KEY`, `GOOGLE_API_KEY`
+   - (Optional) `pip install -e .[local]` to pull in the offline transformers/llama.cpp adapters (install PyTorch per platform instructions).
+2. Set API keys via `.env`:
+   - `GROQ_API_KEYS=["key1","key2"]` (JSON list parsed with `json.loads`)
+   - `GROQ_API_KEY_CONCURRENCY={"key1":2,"key2":4}` to override per-key concurrency (defaults to `DEFAULT_MAX_CONCURRENCY`)
+   - `DEFAULT_MAX_CONCURRENCY=1` fallback when a key is missing above
+   - `GOOGLE_API_KEY` or `GEMINI_API_KEY`
 3. Run a pilot pair and write logs:
    - Echo: `python scripts/run_pilot_trial.py --config configs/pilot.yaml --backend echo --out trial_logs.jsonl`
+   - Local (transformers): `python scripts/run_pilot_trial.py --config configs/pilot.yaml --backend local --model distilgpt2 --backend-param model_name=distilgpt2 --out trial_logs.jsonl`
+   - Local (llama.cpp): `python scripts/run_pilot_trial.py --config configs/pilot.yaml --backend local --backend-param provider=llama_cpp --backend-param model_path=models/llama.gguf --out trial_logs.jsonl`
    - Groq: `python scripts/run_pilot_trial.py --config configs/pilot.yaml --backend groq --model llama3-8b-8192 --out trial_logs.jsonl`
    - Gemini: `python scripts/run_pilot_trial.py --config configs/pilot.yaml --backend gemini --model gemini-1.5-flash --out trial_logs.jsonl`
+   - Add `--placebo <key>` (e.g., `name_placebo`) to schedule additional negative-control pairs if you are not using the sample YAML.
+   - Provide `--manifest runs/pilot_manifest.jsonl` to co-save per-run metadata with prompt hashes.
+4. Calibrate and inspect the frozen tone classifier: `python scripts/run_tone_calibration.py`
+5. Run a batch across cases/models: `python scripts/run_trial_matrix.py --config configs/batch.yaml --out runs/batch_logs.jsonl --manifest runs/batch_manifest.jsonl`
+
+## Verdict JSON Contract
+During the VERDICT phase the judge agent must begin its response with a JSON object containing a `verdict` key (and optionally `sentence`). Narrative rationale can follow on subsequent lines, but the leading JSON block is required so `_parse_and_set_verdict_sentence()` can populate `TrialLog.verdict`/`sentence`.
 
 ## Repository Layout
 - `bailiff/core`: State machine, config, logging, session engine, JSONL I/O
 - `bailiff/agents`: Agent abstractions, prompts, optional Groq/Gemini backends
 - `bailiff/datasets`: Case templates and cue catalogs
 - `bailiff/orchestration`: Randomization and pipelines for paired trials
+- `bailiff/schemas`: JSON Schemas (TrialLog) used for validation
 - `bailiff/metrics`: Outcome and procedural metrics/utilities
 - `bailiff/analysis`: Lightweight statistical helpers
-- `scripts/`: CLI entry points (pilot runner)
+- `scripts/`: CLI entry points (pilot runner, tone calibration report)
 - `docs/`: User guide and API reference
 
 ## Learn More
 - Design overview and diagrams: `DESIGN.md`
 - User guide (install, run, add case/cue/backend, analysis): `docs/USER_GUIDE.md`
 - API reference (core modules): `docs/API.md`
+- Measurement-error calibration CLI: `scripts/run_measurement_calibration.py`
+- Outcome scripts (GLMM, GEE+Satterthwaite, wild cluster bootstrap): `docs/OUTCOME_SCRIPTS.md`
+- Local backend reference: `docs/USER_GUIDE.md#local-backend-options`
+
+## Groq key pool
+- `GroqBackend` now pulls from a pool of keys and rotates to the least-used key that has spare concurrency.
+- Rate-limit responses put the offending key into an exponential backoff window (up to 30s) so the next request can failover to a different key automatically.
+- Configure keys/concurrency in `.env` using `GROQ_API_KEYS`, optional `GROQ_API_KEY_CONCURRENCY`, and `DEFAULT_MAX_CONCURRENCY`.
+- Per-key status (inflight, uses, backoff) is captured by `GroqKeyStatus` and available via `GroqKeyPool.summary()` if you need to log/debug pool health.
+- Best practices: spread keys across Groq projects, set realistic concurrency caps from your Groq dashboard, and keep the default low so a single runaway job cannot exhaust the pool.
 
 ## FAQ
-- How do I add a new case? Create a YAML under `bailiff/datasets/cases/` with `summary`, `facts`, `witnesses`, and `cue_slots`. See the user guide.
+- How do I add a new case? Create a YAML under `bailiff/datasets/cases/` with `summary`, `facts`, `witnesses`, and `cue_slots`, then run `load_case_templates()` to validate it. See the user guide.
 - How do I add a cue? Extend `cue_catalog()` in `bailiff/datasets/templates.py`.
 - How do I analyze results? Export JSONL from the runner and follow the analysis examples in `docs/USER_GUIDE.md`.
-

--- a/bailiff.egg-info/SOURCES.txt
+++ b/bailiff.egg-info/SOURCES.txt
@@ -10,7 +10,9 @@ bailiff.egg-info/requires.txt
 bailiff.egg-info/top_level.txt
 bailiff/agents/__init__.py
 bailiff/agents/backends.py
+bailiff/agents/backends_local.py
 bailiff/agents/base.py
+bailiff/agents/groq_pool.py
 bailiff/agents/prompts.py
 bailiff/analysis/stats.py
 bailiff/core/__init__.py
@@ -18,7 +20,9 @@ bailiff/core/config.py
 bailiff/core/events.py
 bailiff/core/io.py
 bailiff/core/logging.py
+bailiff/core/schema.py
 bailiff/core/session.py
+bailiff/core/tokenizer.py
 bailiff/datasets/__init__.py
 bailiff/datasets/templates.py
 bailiff/metrics/__init__.py
@@ -26,6 +30,14 @@ bailiff/metrics/outcome.py
 bailiff/metrics/procedural.py
 bailiff/metrics/tone.py
 bailiff/orchestration/__init__.py
+bailiff/orchestration/blocks.py
 bailiff/orchestration/pipeline.py
 bailiff/orchestration/randomization.py
+bailiff/schemas/__init__.py
+tests/test_core_suite.py
 tests/test_e2e_echo.py
+tests/test_groq_pool.py
+tests/test_session.py
+tests/test_token_budget.py
+tests/test_tone_pipeline.py
+tests/test_verdict_parser.py

--- a/bailiff.egg-info/requires.txt
+++ b/bailiff.egg-info/requires.txt
@@ -2,11 +2,14 @@ numpy>=1.24
 pandas>=2.0
 scipy>=1.10
 statsmodels>=0.14
+jsonschema>=4.21
 pydantic>=2.5
 pydantic-settings>=2.1
 pyyaml>=6.0
 python-dotenv>=1.0
 tqdm>=4.66
+scikit-learn>=1.3
+tiktoken>=0.7
 
 [agent]
 openai>=1.40
@@ -18,3 +21,7 @@ google-generativeai>=0.7
 matplotlib>=3.8
 seaborn>=0.13
 plotnine>=0.12
+
+[local]
+transformers>=4.41
+llama-cpp-python>=0.2

--- a/bailiff/agents/backends.py
+++ b/bailiff/agents/backends.py
@@ -7,32 +7,64 @@ optional packages present.
 from __future__ import annotations
 
 import os
-from typing import Optional
+from typing import Dict, List, Optional
+
+from .groq_pool import GroqKeyPool
 
 
 class GroqBackend:
-    """Adapter for Groq chat.completions API."""
+    """Adapter for Groq chat.completions API with key rotation and backoff."""
 
-    def __init__(self, model: str, api_key: Optional[str] = None):
+    def __init__(self, model: str, api_key: Optional[str] = None, api_keys: Optional[List[str]] = None):
         try:  # pragma: no cover - optional dep
             from groq import Groq  # type: ignore
         except Exception as e:  # pragma: no cover - optional dep
             raise ImportError("groq package not installed") from e
         self._Groq = Groq
         self._model = model
-        self._api_key = api_key or os.getenv("GROQ_API_KEY")
-        if not self._api_key:
-            raise RuntimeError("GROQ_API_KEY is required")
-        self._client = Groq(api_key=self._api_key)
+        explicit_keys = [api_key] if api_key else api_keys
+        self._pool = GroqKeyPool.from_env(api_keys=explicit_keys)
+        self._clients: Dict[str, object] = {}
 
     def __call__(self, prompt: str, **kwargs: object) -> str:  # pragma: no cover - network
-        resp = self._client.chat.completions.create(
-            model=self._model,
-            messages=[{"role": "user", "content": prompt}],
-            temperature=kwargs.get("temperature", 0.2),
-            max_tokens=kwargs.get("max_tokens", 512),
-        )
-        return resp.choices[0].message.content or ""
+        """Make a chat completion request with automatic retry on rate limits.
+        
+        Retries infinitely with exponential backoff (capped at 30s) until a request succeeds.
+        Automatically rotates through available keys and waits for backoff periods to expire.
+        """
+        import time
+        
+        while True:
+            try:
+                # Try to acquire a key, waiting if necessary
+                with self._pool.acquire(wait=True, max_wait=30.0) as lease:
+                    client = self._clients.get(lease.key)
+                    if client is None:
+                        client = self._Groq(api_key=lease.key)
+                        self._clients[lease.key] = client
+                    try:
+                        resp = client.chat.completions.create(
+                            model=self._model,
+                            messages=[{"role": "user", "content": prompt}],
+                            temperature=kwargs.get("temperature", 0.2),
+                            max_tokens=kwargs.get("max_tokens", 512),
+                        )
+                        lease.mark_success()
+                        return resp.choices[0].message.content or ""
+                    except Exception as exc:  # pragma: no cover - network
+                        if _is_rate_limit_error(exc):
+                            lease.mark_rate_limited(exc)
+                            # The backoff is already set in the key status, so we'll wait
+                            # when trying to acquire the next key. Just continue the loop.
+                        else:
+                            lease.mark_failure(exc)
+                            # For non-rate-limit errors, wait a bit before retry
+                            time.sleep(1.0)
+                        # Continue loop to retry with a different key
+            except RuntimeError:
+                # No keys available - wait and retry
+                time.sleep(1.0)
+                continue
 
 
 class GeminiBackend:
@@ -54,4 +86,16 @@ class GeminiBackend:
     def __call__(self, prompt: str, **kwargs: object) -> str:  # pragma: no cover - network
         resp = self._model.generate_content(prompt)
         return getattr(resp, "text", "") or ""
+
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    """Best-effort detection of Groq rate limit responses."""
+
+    if exc.__class__.__name__ == "RateLimitError":
+        return True
+    status = getattr(exc, "status_code", None)
+    if status == 429:
+        return True
+    message = str(exc)
+    return "429" in message or "rate limit" in message.lower()
 

--- a/bailiff/agents/groq_pool.py
+++ b/bailiff/agents/groq_pool.py
@@ -1,0 +1,274 @@
+"""Groq API key pool with rotation, concurrency limits, and backoff."""
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass(slots=True)
+class GroqKeyStatus:
+    """Tracks usage statistics and throttling state for a Groq API key."""
+
+    key: str
+    max_concurrency: int
+    total_uses: int = 0
+    inflight: int = 0
+    consecutive_rate_limits: int = 0
+    last_error: Optional[str] = None
+    backoff_until: float = 0.0
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+    def is_available(self, now: Optional[float] = None) -> bool:
+        """Return True if the key can accept another request."""
+
+        current = now if now is not None else time.monotonic()
+        return self.inflight < self.max_concurrency and current >= self.backoff_until
+
+    def snapshot(self) -> Dict[str, object]:
+        """Produce a serializable summary for logging or debugging."""
+
+        return {
+            "key": self.key[-6:],  # avoid dumping full secrets
+            "max_concurrency": self.max_concurrency,
+            "inflight": self.inflight,
+            "total_uses": self.total_uses,
+            "consecutive_rate_limits": self.consecutive_rate_limits,
+            "backoff_remaining": max(self.backoff_until - time.monotonic(), 0),
+            "last_error": self.last_error,
+        }
+
+
+class GroqKeyLease:
+    """Context manager that represents a reserved Groq API key."""
+
+    def __init__(self, pool: "GroqKeyPool", status: GroqKeyStatus):
+        self._pool = pool
+        self._status = status
+        self.key = status.key
+        self._released = False
+
+    def mark_success(self) -> None:
+        self._release(success=True)
+
+    def mark_failure(self, error: Exception) -> None:
+        self._release(success=False, error=error, rate_limited=False)
+
+    def mark_rate_limited(self, error: Exception) -> None:
+        self._release(success=False, error=error, rate_limited=True)
+
+    def _release(self, success: bool, error: Optional[Exception] = None, rate_limited: bool = False) -> None:
+        if self._released:
+            return
+        self._pool._release(self._status, success=success, error=error, rate_limited=rate_limited)
+        self._released = True
+
+    def __enter__(self) -> "GroqKeyLease":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._released:
+            return
+        if exc is None:
+            self.mark_success()
+        elif exc_type and issubclass(exc_type, Exception):
+            self.mark_failure(exc)  # pragma: no cover - defensive
+
+
+class GroqKeyPool:
+    """Selects the least-used Groq API key while respecting concurrency and backoff."""
+
+    MAX_BACKOFF_SECONDS = 30
+
+    def __init__(self, statuses: Iterable[GroqKeyStatus]):
+        statuses = list(statuses)
+        if not statuses:
+            raise ValueError("At least one Groq API key must be provided")
+        self._statuses = {status.key: status for status in statuses}
+        self._order = {status.key: idx for idx, status in enumerate(statuses)}
+        self._lock = threading.Lock()
+
+    @classmethod
+    def from_env(
+        cls,
+        api_keys: Optional[List[str]] = None,
+        concurrency_map: Optional[Dict[str, int]] = None,
+        default_concurrency: Optional[int] = None,
+    ) -> "GroqKeyPool":
+        """Build the pool from environment variables."""
+
+        if api_keys is None:
+            api_keys = _load_key_list()
+        if concurrency_map is None:
+            concurrency_map = _load_concurrency_map()
+        if default_concurrency is None:
+            default_concurrency = _load_default_concurrency()
+        statuses = [
+            GroqKeyStatus(key=key, max_concurrency=concurrency_map.get(key, default_concurrency))
+            for key in api_keys
+        ]
+        return cls(statuses)
+
+    def acquire(self, wait: bool = False, max_wait: float = 30.0) -> GroqKeyLease:
+        """Reserve the least-used key that is currently available.
+        
+        Args:
+            wait: If True and no keys are available, wait until one becomes available
+            max_wait: Maximum seconds to wait (capped at 30.0)
+        """
+        max_wait = min(max_wait, 30.0)
+        
+        # First try without waiting
+        with self._lock:
+            try:
+                status = self._select_next()
+                status.inflight += 1
+                return GroqKeyLease(self, status)
+            except RuntimeError:
+                if not wait:
+                    raise
+        
+        # Need to wait - release lock and wait
+        start = time.monotonic()
+        while time.monotonic() - start < max_wait:
+            # Check which key will be available soonest
+            with self._lock:
+                now = time.monotonic()
+                candidates = [
+                    (status, max(status.backoff_until - now, 0))
+                    for status in self._statuses.values()
+                    if status.inflight < status.max_concurrency
+                ]
+                if not candidates:
+                    # All keys at capacity, wait a bit and retry
+                    wait_time = 0.1
+                else:
+                    # Sort by backoff remaining, then by usage
+                    candidates.sort(key=lambda x: (x[1], x[0].total_uses, x[0].inflight))
+                    status, backoff_remaining = candidates[0]
+                    if backoff_remaining <= 0 and status.is_available(now):
+                        # Key is available now
+                        status.inflight += 1
+                        return GroqKeyLease(self, status)
+                    # Wait for backoff or a short delay
+                    wait_time = min(backoff_remaining + 0.1, max_wait - (now - start), 0.5)
+            
+            # Release lock while sleeping
+            if wait_time > 0:
+                time.sleep(wait_time)
+            
+            # Try to acquire again
+            with self._lock:
+                try:
+                    status = self._select_next()
+                    status.inflight += 1
+                    return GroqKeyLease(self, status)
+                except RuntimeError:
+                    # Still no keys available, continue waiting
+                    if time.monotonic() - start >= max_wait:
+                        # Final attempt
+                        status = self._select_next()
+                        status.inflight += 1
+                        return GroqKeyLease(self, status)
+                    continue
+
+    @property
+    def keys(self) -> List[str]:
+        """Return the ordered list of managed keys."""
+
+        with self._lock:
+            return list(self._statuses.keys())
+
+    def summary(self) -> List[Dict[str, object]]:
+        """Return a snapshot of each key's status for logging/debugging."""
+
+        with self._lock:
+            return [status.snapshot() for status in self._statuses.values()]
+
+    def _select_next(self) -> GroqKeyStatus:
+        now = time.monotonic()
+        eligible = [status for status in self._statuses.values() if status.is_available(now)]
+        if not eligible:
+            raise RuntimeError("No Groq API keys are currently available (all throttled or at capacity)")
+        eligible.sort(key=lambda s: (s.total_uses, s.inflight, self._order[s.key]))
+        return eligible[0]
+
+    def _release(self, status: GroqKeyStatus, success: bool, error: Optional[Exception], rate_limited: bool) -> None:
+        with self._lock:
+            if status.inflight > 0:
+                status.inflight -= 1
+            if success:
+                status.total_uses += 1
+                status.consecutive_rate_limits = 0
+                status.last_error = None
+                status.backoff_until = 0.0
+            else:
+                status.last_error = str(error) if error else None
+                if rate_limited:
+                    status.consecutive_rate_limits += 1
+                    delay = min(2 ** status.consecutive_rate_limits, self.MAX_BACKOFF_SECONDS)
+                    status.backoff_until = time.monotonic() + delay
+                else:
+                    status.consecutive_rate_limits = 0
+
+
+def _load_key_list() -> List[str]:
+    """Load Groq API keys from environment variables with fallback."""
+
+    raw_list = os.getenv("GROQ_API_KEYS")
+    if raw_list:
+        try:
+            parsed = json.loads(raw_list)
+        except json.JSONDecodeError as err:  # pragma: no cover - defensive
+            raise ValueError("GROQ_API_KEYS must be valid JSON") from err
+        if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
+            raise ValueError("GROQ_API_KEYS must be a JSON list of strings")
+        keys = [item.strip() for item in parsed if item.strip()]
+        if not keys:
+            raise ValueError("GROQ_API_KEYS cannot be empty")
+        return keys
+
+    single = os.getenv("GROQ_API_KEY")
+    if single:
+        return [single.strip()]
+    raise RuntimeError("Set GROQ_API_KEYS (JSON list) or GROQ_API_KEY in the environment")
+
+
+def _load_concurrency_map() -> Dict[str, int]:
+    """Parse per-key concurrency overrides from env."""
+
+    raw_map = os.getenv("GROQ_API_KEY_CONCURRENCY")
+    if not raw_map:
+        return {}
+    try:
+        parsed = json.loads(raw_map)
+    except json.JSONDecodeError as err:  # pragma: no cover - defensive
+        raise ValueError("GROQ_API_KEY_CONCURRENCY must be valid JSON") from err
+    if not isinstance(parsed, dict):
+        raise ValueError("GROQ_API_KEY_CONCURRENCY must be a JSON object")
+    result: Dict[str, int] = {}
+    for key, value in parsed.items():
+        try:
+            result[key] = int(value)
+        except (TypeError, ValueError) as err:  # pragma: no cover - defensive
+            raise ValueError("Concurrency limits must be integers") from err
+        if result[key] <= 0:
+            raise ValueError("Concurrency limits must be positive integers")
+    return result
+
+
+def _load_default_concurrency() -> int:
+    """Read the default concurrency fallback from env."""
+
+    raw_default = os.getenv("DEFAULT_MAX_CONCURRENCY", "1")
+    try:
+        value = int(raw_default)
+    except ValueError as err:  # pragma: no cover - defensive
+        raise ValueError("DEFAULT_MAX_CONCURRENCY must be an integer") from err
+    if value <= 0:
+        raise ValueError("DEFAULT_MAX_CONCURRENCY must be greater than zero")
+    return value
+

--- a/tests/test_groq_pool.py
+++ b/tests/test_groq_pool.py
@@ -1,0 +1,53 @@
+import json
+
+import pytest
+
+from bailiff.agents.groq_pool import GroqKeyPool
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch):
+    monkeypatch.delenv("GROQ_API_KEYS", raising=False)
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    monkeypatch.delenv("GROQ_API_KEY_CONCURRENCY", raising=False)
+    monkeypatch.delenv("DEFAULT_MAX_CONCURRENCY", raising=False)
+
+
+def test_least_used_rotation(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEYS", json.dumps(["k1", "k2"]))
+    pool = GroqKeyPool.from_env()
+
+    with pool.acquire() as first:
+        assert first.key == "k1"
+
+    with pool.acquire() as second:
+        assert second.key == "k2"
+
+
+def test_concurrency_limits_force_failover(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEYS", json.dumps(["k1", "k2"]))
+    monkeypatch.setenv("GROQ_API_KEY_CONCURRENCY", json.dumps({"k1": 1, "k2": 2}))
+    pool = GroqKeyPool.from_env()
+
+    lease_one = pool.acquire()
+    assert lease_one.key == "k1"
+
+    lease_two = pool.acquire()
+    assert lease_two.key == "k2"
+
+    lease_two.mark_success()
+    lease_one.mark_success()
+
+
+def test_rate_limit_triggers_backoff(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEYS", json.dumps(["k1", "k2"]))
+    pool = GroqKeyPool.from_env()
+
+    with pool.acquire() as lease:
+        assert lease.key == "k1"
+        lease.mark_rate_limited(RuntimeError("429"))
+
+    with pool.acquire() as next_lease:
+        assert next_lease.key == "k2"
+        next_lease.mark_success()
+


### PR DESCRIPTION
- Implemented multi-key Groq runner to shuffle between multiple Groq API keys depending on usage
- `GroqBackend` now pulls from a pool of keys and rotates to the least-used key that has spare concurrency.
- Rate-limit responses put the offending key into an exponential backoff window (up to 30s) so the next request can failover to a different key automatically.
- Configure keys/concurrency in `.env` using `GROQ_API_KEYS`, optional `GROQ_API_KEY_CONCURRENCY`, and `DEFAULT_MAX_CONCURRENCY`.
- Sample env provided in .env.sample, change values of `your_key1`, `your_key2`, ... to your Groq API keys
- Per-key status (inflight, uses, backoff) is captured by `GroqKeyStatus` and available via `GroqKeyPool.summary()` if you need to log/debug pool health.
 
